### PR TITLE
django-constance compatability

### DIFF
--- a/admin_site_search/views.py
+++ b/admin_site_search/views.py
@@ -50,6 +50,9 @@ class AdminSiteSearchView:
                 if not can_view:
                     # user has no permission to view this model, so skip
                     continue
+                # Package is not compatible with Django Constance yet
+                if app["app_label"] == "constance":
+                    continue
 
                 model_class = model.get(  # model class added to dict in django 4.x
                     "model", apps.get_model(app["app_label"], model["object_name"])


### PR DESCRIPTION
Skip django-Constance in search due to the model name is not `Config` more detail about the error [here](https://github.com/ahmedaljawahiry/django-admin-site-search/issues/6) 