### PR TITLE
13 Support urlconf with admin as index

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ class MyAdminSite(AdminSiteSearchView, admin.AdminSite):
     ...
 ```
 
+By default, the search route is at `<admin_path>/search/`. The last part can be changed by overriding 
+the `site_search_path` class variable in your admin site.
+
+
 ### 3. Add Templates
 
 1. If you haven't already, create `admin/base_site.html` in your `templates/` directory.

--- a/admin_site_search/static/admin_site_search/search.js
+++ b/admin_site_search/static/admin_site_search/search.js
@@ -28,11 +28,27 @@ document.addEventListener('alpine:init', () => {
     }
 
     /**
+     * Retrieves the admin search path from the script element's data-search-path attribute.
+     *
+     * This method allows us to reverse admin:index in the template.
+     */
+    function getSearchPath() {
+        const scriptElement = document.getElementById('admin-site-search-script');
+
+        let path = scriptElement?.dataset.searchPath;
+        if (!path) {
+            path = "/admin/search/";
+            console.warn("admin-site-search", `Failed to detect admin search path (default=${path})`);
+        }
+
+        return path;
+    }
+
+    /**
      * State/functions for performing searches.
      */
     Alpine.data('siteSearch', () => {
-        const adminPath = window.location.pathname.split('/')[1] ||  '';
-        const adminSearchPath = adminPath ? `/${adminPath}/search/` : '/search/';
+        const adminSearchPath = getSearchPath();
         const minChars = 2;
         const resultsEmpty = { apps: [] };
 
@@ -90,7 +106,7 @@ document.addEventListener('alpine:init', () => {
                         }
                     } catch (e) {
                         this.helpText = 'An unexpected error occurred';
-                        console.error(e);
+                        console.error("admin-site-search", e);
                     }
                 }
             },

--- a/admin_site_search/templates/admin_site_search/head.html
+++ b/admin_site_search/templates/admin_site_search/head.html
@@ -2,7 +2,7 @@
 {% if not is_popup and request.user.is_authenticated %}
     <script src="{% static 'admin_site_search/alpinejs/focus-3-12-0.min.js' %}" defer></script>
     <script src="{% static 'admin_site_search/alpinejs/3-12-0.min.js' %}" defer></script>
-    <script src="{% static 'admin_site_search/search.js' %}"></script>
+    <script src="{% static 'admin_site_search/search.js' %}" id="admin-site-search-script" data-search-path="{% url 'admin:index' %}search/"></script>
     <link rel="stylesheet" href="{% static 'admin_site_search/style.css' %}">
     <style>
         {# Prevent "Alpine flash": https://ryangjchandler.co.uk/posts/hiding-elements-until-alpine-is-ready-with-x-cloak#}

--- a/admin_site_search/templates/admin_site_search/head.html
+++ b/admin_site_search/templates/admin_site_search/head.html
@@ -2,7 +2,7 @@
 {% if not is_popup and request.user.is_authenticated %}
     <script src="{% static 'admin_site_search/alpinejs/focus-3-12-0.min.js' %}" defer></script>
     <script src="{% static 'admin_site_search/alpinejs/3-12-0.min.js' %}" defer></script>
-    <script src="{% static 'admin_site_search/search.js' %}" id="admin-site-search-script" data-search-path="{% url 'admin:index' %}search/"></script>
+    <script src="{% static 'admin_site_search/search.js' %}" id="admin-site-search-script" data-search-path="{% url 'admin:site-search' %}"></script>
     <link rel="stylesheet" href="{% static 'admin_site_search/style.css' %}">
     <style>
         {# Prevent "Alpine flash": https://ryangjchandler.co.uk/posts/hiding-elements-until-alpine-is-ready-with-x-cloak#}

--- a/admin_site_search/views.py
+++ b/admin_site_search/views.py
@@ -14,6 +14,7 @@ class AdminSiteSearchView:
         """Extends super()'s urls, to include search/"""
         urlpatterns = super().get_urls()
 
+        # todo: make "search/" configurable
         search = path("search/", self.admin_view(self.search), name="search")
         # avoid append(), to keep the "catch_all_view" last
         urlpatterns.insert(0, search)

--- a/admin_site_search/views.py
+++ b/admin_site_search/views.py
@@ -10,13 +10,16 @@ from django.urls import path
 class AdminSiteSearchView:
     """Adds a search/ view, to the admin site"""
 
+    site_search_path = "search/"
+
     def get_urls(self):
         """Extends super()'s urls, to include search/"""
         urlpatterns = super().get_urls()
 
-        # todo: make "search/" configurable
-        search = path("search/", self.admin_view(self.search), name="site-search")
-        # avoid append(), to keep the "catch_all_view" last
+        search = path(
+            self.site_search_path, self.admin_view(self.search), name="site-search"
+        )
+        # avoid append() so that "catch_all_view" is last
         urlpatterns.insert(0, search)
 
         return urlpatterns

--- a/admin_site_search/views.py
+++ b/admin_site_search/views.py
@@ -15,7 +15,7 @@ class AdminSiteSearchView:
         urlpatterns = super().get_urls()
 
         # todo: make "search/" configurable
-        search = path("search/", self.admin_view(self.search), name="search")
+        search = path("search/", self.admin_view(self.search), name="site-search")
         # avoid append(), to keep the "catch_all_view" last
         urlpatterns.insert(0, search)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,8 +3,8 @@ from django.urls import reverse
 
 
 def request_search(client: Client, query: str = ""):
-    """Returns the response after performing a GET request against the "admin:search"
+    """Returns the response after performing a GET request against the "admin:site-search"
     endpoint, with the given client and query"""
-    url = f'{reverse("admin:search")}?q={query}'
+    url = f'{reverse("admin:site-search")}?q={query}'
 
     return client.get(url)

--- a/tests/server/test_templates.py
+++ b/tests/server/test_templates.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 ELEMENTS_CUSTOM = [
     '<script src="/static/admin_site_search/alpinejs/focus-3-12-0.min.js" defer>',
     '<script src="/static/admin_site_search/alpinejs/3-12-0.min.js" defer>',
-    '<script src="/static/admin_site_search/search.js">',
+    '<script src="/static/admin_site_search/search.js',
     "[x-cloak] { display: none !important;}",
     '<link rel="stylesheet" href="/static/admin_site_search/style.css">',
     '<template x-data x-if="$store.search.isOpen">',

--- a/tests/server/test_url/test_path.py
+++ b/tests/server/test_url/test_path.py
@@ -1,0 +1,45 @@
+"""Verify that the search path supports admin sites with custom URLs"""
+import re
+
+from django.test import Client, override_settings
+from django.urls import reverse
+
+
+def request_script_element(client: Client):
+    """Requests admin:index, then parses the content for the search.js script element. This should
+    contain the necessary attributes to detect the admin URL."""
+    response = client.get(reverse("admin:index"), follow=True)
+    content = str(response.content)
+
+    script_element = re.search(
+        r'<script src="/static/admin_site_search/search.js.*</script>', content
+    ).group(0)
+
+    return script_element
+
+
+@override_settings(ROOT_URLCONF="tests.server.test_url.urls_default")
+def test_default(client_super_admin):
+    """Verify the correct URL is set for default url conf"""
+    element = request_script_element(client_super_admin)
+
+    assert 'id="admin-site-search-script"' in element
+    assert 'data-search-path="/admin/search/"' in element
+
+
+@override_settings(ROOT_URLCONF="tests.server.test_url.urls_custom")
+def test_custom(client_super_admin):
+    """Verify the correct URL is set for a custom url conf"""
+    element = request_script_element(client_super_admin)
+
+    assert 'id="admin-site-search-script"' in element
+    assert 'data-search-path="/custom/search/"' in element
+
+
+@override_settings(ROOT_URLCONF="tests.server.test_url.urls_index")
+def test_index(client_super_admin):
+    """Verify the correct URL is set for a custom url conf, with the admin at the index"""
+    element = request_script_element(client_super_admin)
+
+    assert 'id="admin-site-search-script"' in element
+    assert 'data-search-path="/search/"' in element

--- a/tests/server/test_url/test_path.py
+++ b/tests/server/test_url/test_path.py
@@ -4,6 +4,8 @@ import re
 from django.test import Client, override_settings
 from django.urls import reverse
 
+from admin_site_search.views import AdminSiteSearchView
+
 
 def request_script_element(client: Client):
     """Requests admin:index, then parses the content for the search.js script element. This should
@@ -43,3 +45,12 @@ def test_index(client_super_admin):
 
     assert 'id="admin-site-search-script"' in element
     assert 'data-search-path="/search/"' in element
+
+
+def test_path_attr():
+    """Verify that the AdminSiteSearchView has a "site_search_path", which is used to generate
+    the search route"""
+
+    # basic assertions to avoid crazy patches - this is more of a sanity test to prevent API breakages
+    assert hasattr(AdminSiteSearchView, "site_search_path")
+    assert reverse("admin:site-search").endswith(AdminSiteSearchView.site_search_path)

--- a/tests/server/test_url/urls_custom.py
+++ b/tests/server/test_url/urls_custom.py
@@ -1,0 +1,7 @@
+"""URL conf for a project where the admin site is on a custom URL"""
+from django.contrib import admin
+from django.urls import path
+
+urlpatterns = [
+    path("custom/", admin.site.urls),
+]

--- a/tests/server/test_url/urls_default.py
+++ b/tests/server/test_url/urls_default.py
@@ -1,0 +1,7 @@
+"""URL conf for a project with a default admin URL"""
+from django.contrib import admin
+from django.urls import path
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+]

--- a/tests/server/test_url/urls_index.py
+++ b/tests/server/test_url/urls_index.py
@@ -1,0 +1,7 @@
+"""URL conf for a project where the admin site is the index URL"""
+from django.contrib import admin
+from django.urls import path
+
+urlpatterns = [
+    path("", admin.site.urls),
+]

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
     dj42: django==4.2.*
 description = run server/unit tests.
 commands =
-    python -W error::DeprecationWarning -m pip freeze
+    python -m pip freeze
     python -m coverage run -m pytest tests/server
 setenv =
     PYTHONDEVMODE=1


### PR DESCRIPTION
Instead of inferring the admin path client-side, with `window.location.pathname`, pass it through via `{% url ... %}`. This should prevent issues like https://github.com/ahmedaljawahiry/django-admin-site-search/issues/13, and is slightly more explicit.