### PR TITLE
chore: consistently lower case the query in at search level

### DIFF
--- a/admin_site_search/views.py
+++ b/admin_site_search/views.py
@@ -28,7 +28,7 @@ class AdminSiteSearchView:
         """Returns a JsonResponse containing results from matching the "q" query parameter to
         application names, model names, and all instance CharFields. Only apps/models that the
         user has permission to view are searched."""
-        query = request.GET.get("q", "").lower()
+        query = request.GET.get("q", "")
 
         results = {"apps": []}
         counts = {"apps": 0, "models": 0, "objects": 0}
@@ -154,8 +154,9 @@ class AdminSiteSearchView:
 
     def filter_field(self, query: str, field: Field) -> Optional[Q]:
         """Returns a Q 'icontains' filter for Char fields, otherwise None"""
+        _query = query.lower()
         if isinstance(field, CharField):
-            return Q(**{f"{field.name}__icontains": query})
+            return Q(**{f"{field.name}__icontains": _query})
 
     def get_model_class(self, app_label: str, model_dict: dict) -> Optional[Model]:
         """Retrieve the model class from the dict created by admin.AdminSite, which (by default) contains:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-admin-site-search
-version = 0.4.0
+version = 0.4.1
 description = A search (cmd+k) modal, for the Django admin UI, that searches your entire site.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
At the moment, because the query is lower-cased in `def search`, there is no way to reimplement and of the `match_` methods with case sensitive search.

The query is already being lower-cased in `match_app` and `match_model`. Added lower-casing to `filter_field` and removed it from `search`.

This will amke the plugin more flexible.