### PR TITLE
Option to delegate search to model admin's search_fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,29 +105,29 @@ class MyAdminSite(AdminSiteSearchView, admin.AdminSite):
 ### Methods
 
 ```python 
-def match_app(self, query: str, name: str) -> bool:
+def match_app(self, request, query: str, name: str) -> bool:
     """DEFAULT: case-insensitive match the app name"""
     ...
 
 def match_model(
-    self, query: str, name: str, object_name: str, fields: List[Field]
+    self, request, query: str, name: str, object_name: str, fields: List[Field]
 ) -> bool:
     """DEFAULT: case-insensitive match the model and field attributes"""
     ...
 
 def match_objects(
-    self, query: str, model_class: Model, model_fields: List[Field]
+    self, request, query: str, model_class: Model, model_fields: List[Field]
 ) -> QuerySet:
     """DEFAULT: Returns the QuerySet after performing an OR filter across all Char fields in the model."""
     ...
 
-def filter_field(self, query: str, field: Field) -> Optional[Q]:
+def filter_field(self, request, query: str, field: Field) -> Optional[Q]:
     """DEFAULT: Returns a Q 'icontains' filter for Char fields, otherwise None
     
     Note: this method is only invoked if model_char_fields is the site_search_method."""
     ...
 
-def get_model_class(self, app_label: str, model_dict: dict) -> Optional[Model]:
+def get_model_class(self, request, app_label: str, model_dict: dict) -> Optional[Model]:
     """DEFAULT: Retrieve the model class from the dict created by admin.AdminSite"""
     ...
 ```
@@ -146,7 +146,7 @@ class MyAdminSite(AdminSiteSearchView, admin.AdminSite):
     
     site_search_method: "model_char_fields"  
   
-    def filter_field(self, query: str, field: Field) -> Optional[Q]:
+    def filter_field(self, request, query: str, field: Field) -> Optional[Q]:
         """Extends super() to add TextField support to site search"""
         if isinstance(field, TextField):
             return Q(**{f"{field.name}__icontains": query})

--- a/admin_site_search/views.py
+++ b/admin_site_search/views.py
@@ -160,6 +160,7 @@ class AdminSiteSearchView:
 
     def get_model_class(self, app_label: str, model_dict: dict) -> Optional[Model]:
         """Retrieve the model class from the dict created by admin.AdminSite, which (by default) contains:
+
         - "model": the class instance (only available in Django 4.x),
         - "name": capitalised verbose_name_plural,
         - "object_name": the class name,

--- a/dev/football/teams/admin.py
+++ b/dev/football/teams/admin.py
@@ -8,11 +8,11 @@ from dev.football.teams.models import Squad, Team
 class TeamAdmin(BaseAdmin):
     """Admin for the Team model"""
 
-    pass
+    search_fields = ("name", "description", "=key")
 
 
 @admin.register(Squad)
 class SquadAdmin(BaseAdmin):
     """Admin for the Squad model"""
 
-    pass
+    search_fields = ("team__name", "players__name")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,10 +1,30 @@
+from typing import Optional
+from unittest.mock import patch
+
 from django.test import Client
 from django.urls import reverse
 
+from admin_site_search.views import AdminSiteSearchView, SiteSearchMethodType
 
-def request_search(client: Client, query: str = ""):
+
+def request_search(
+    client: Client,
+    query: str = "",
+    site_search_method: Optional[SiteSearchMethodType] = None,
+):
     """Returns the response after performing a GET request against the "admin:site-search"
-    endpoint, with the given client and query"""
+    endpoint, with the given client and query.
+
+    If site_search_method is given, the value is set via patch.object(...)."""
     url = f'{reverse("admin:site-search")}?q={query}'
 
-    return client.get(url)
+    if site_search_method is None:
+        # by default, don't patch anything
+        response = client.get(url)
+    else:
+        with patch.object(
+            AdminSiteSearchView, "site_search_method", site_search_method
+        ):
+            response = client.get(url)
+
+    return response

--- a/tests/server/test_api.py
+++ b/tests/server/test_api.py
@@ -1,6 +1,7 @@
 """Tests verifying the API response"""
 from unittest.mock import patch
 
+import pytest
 from django.apps import apps
 from django.test import override_settings
 
@@ -188,12 +189,16 @@ def test_counts(client_super_admin):
     assert not data["errors"]
 
 
-def test_limit(client_super_admin):
+@pytest.mark.parametrize("method", ["model_char_fields", "admin_search_fields"])
+def test_limit(client_super_admin, method):
     """Verify that a maximum of 5 objects, for each model is returned"""
     for i in range(8):
         GroupFactory(name=f"Internal {i}")
 
-    response = request_search(client_super_admin, query="internal")
+    response = request_search(
+        client_super_admin, query="internal", site_search_method=method
+    )
+
     data = response.json()
 
     assert response.status_code == 200

--- a/tests/server/test_api.py
+++ b/tests/server/test_api.py
@@ -214,7 +214,7 @@ def test_errors_on(client_super_admin):
     team = TeamFactory(name="Arsenal")
     StadiumFactory(name="Arsenal Stadium")
 
-    def error_if_stadium(app_label, model_dict):
+    def error_if_stadium(_, app_label, model_dict):
         """Fails for the Stadium model, default otherwise"""
         if model_dict["object_name"] == "Stadium":
             raise Exception("A test error occurred")

--- a/tests/server/test_search.py
+++ b/tests/server/test_search.py
@@ -1,10 +1,15 @@
 """Tests verifying functionality for searching/matching apps, models and objects"""
 import pytest
 
-from dev.football.teams.factories import TeamFactory
+from admin_site_search.views import AdminSiteSearchView
+from dev.football.players.admin import PlayerAdmin
+from dev.football.players.factories import PlayerFactory
+from dev.football.teams.admin import SquadAdmin, TeamAdmin
+from dev.football.teams.factories import SquadFactory, TeamFactory
 from tests import request_search
 
 
+@pytest.mark.parametrize("method", ["model_char_fields", "admin_search_fields"])
 @pytest.mark.parametrize(
     "query, results_expected",
     # take care to not match model names or fields
@@ -14,9 +19,11 @@ from tests import request_search
         ("accounting", []),
     ],
 )
-def test_apps(client_super_admin, query, results_expected):
+def test_apps(client_super_admin, method, query, results_expected):
     """Verify 'contains' and case-insensitive matches are applied to the app name"""
-    response = request_search(client_super_admin, query=query)
+    response = request_search(
+        client_super_admin, query=query, site_search_method=method
+    )
 
     data = response.json()
     results_actual = [r["name"] for r in data["results"]["apps"]]
@@ -26,6 +33,7 @@ def test_apps(client_super_admin, query, results_expected):
     assert not set(results_actual).difference(set(results_expected))
 
 
+@pytest.mark.parametrize("method", ["model_char_fields", "admin_search_fields"])
 @pytest.mark.parametrize(
     "query, results_expected",
     [
@@ -41,13 +49,15 @@ def test_apps(client_super_admin, query, results_expected):
         ("playing surface", ["Pitchs"]),
     ],
 )
-def test_models(client_super_admin, query, results_expected):
+def test_models(client_super_admin, method, query, results_expected):
     """Verify 'contains' and case-insensitive matches are applied to:
     - Model name,
     - Model object name,
     - Field names,
     - Field help text."""
-    response = request_search(client_super_admin, query=query)
+    response = request_search(
+        client_super_admin, query=query, site_search_method=method
+    )
 
     data = response.json()
     results_actual = []
@@ -62,19 +72,38 @@ def test_models(client_super_admin, query, results_expected):
 
 
 @pytest.mark.parametrize(
-    "query, results_expected",
+    "method, query, results_expected",
     [
-        ("obj-one", ["obj-one"]),
-        ("-ONE", ["obj-one"]),
-        ("one two", []),
-        ("slug-key", ["obj-one", "obj-two"]),
-        ("two.com", ["obj-two"]),
-        ("Text", []),
+        ("model_char_fields", "obj-one", ["obj-one"]),
+        ("model_char_fields", "obj-two", ["obj-TWO"]),
+        ("model_char_fields", "-ONE", ["obj-one"]),
+        ("model_char_fields", "one two", []),
+        ("model_char_fields", "slug-key", ["obj-one", "obj-TWO"]),
+        ("model_char_fields", "two.com", ["obj-TWO"]),
+        ("model_char_fields", "Text", []),  # TextField not matched
+        ("admin_search_fields", "obj-one", ["obj-one"]),
+        ("admin_search_fields", "obj-two", ["obj-TWO"]),
+        ("admin_search_fields", "-ONE", ["obj-one"]),
+        ("admin_search_fields", "one two", []),
+        ("admin_search_fields", "slug-key", []),  # "=" prefix, so exact match only
+        ("admin_search_fields", "slug-key-obj-one", ["obj-one"]),
+        ("admin_search_fields", "https", []),  # not in admin search_fields
+        ("admin_search_fields", "Text", ["obj-one", "obj-TWO"]),  # TextField is matched
+        ("invalid", "obj", []),
     ],
 )
-def test_objects(client_super_admin, query, results_expected):
-    """Verify object CharFields are matched: 'contains' and case-insensitive. Other fields are not matched."""
-    for i, n in enumerate(["obj-one", "obj-two"], start=999):
+def test_objects(client_super_admin, method, query, results_expected):
+    """
+    Verify that objects are queried as per the site_search_method:
+
+    - model_char_fields: only CharFields are matched, with icontains. Note: contains acts like icontains
+    in SQLite, so we're not currently asserting on the latter.
+    - admin_search_fields: search functionality in the model's corresponding admin class is invoked
+    (https://docs.djangoproject.com/en/5.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.search_fields).
+    - invalid: no objects returned.
+    """
+
+    for i, n in enumerate(["obj-one", "obj-TWO"], start=999):
         TeamFactory(
             id=i,
             name=f"{n}",
@@ -83,7 +112,9 @@ def test_objects(client_super_admin, query, results_expected):
             description=f"Text {n}",
         )
 
-    response = request_search(client_super_admin, query=query)
+    response = request_search(
+        client_super_admin, query=query, site_search_method=method
+    )
 
     data = response.json()
     results_actual = []
@@ -93,6 +124,79 @@ def test_objects(client_super_admin, query, results_expected):
             for obj in model["objects"]:
                 results_actual.append(obj["name"])
 
+    assert TeamAdmin.search_fields == ("name", "description", "=key")
     assert response.status_code == 200
     assert len(results_actual) == len(results_expected)
     assert not set(results_actual).difference(set(results_expected))
+
+
+def test_objects_admin_search_fields_none(client_super_admin):
+    """Verify that objects are not matched if the corresponding admin has no
+    "search_fields" set"""
+    PlayerFactory(name="Test")
+
+    response = request_search(
+        client_super_admin, query="Test", site_search_method="admin_search_fields"
+    )
+
+    data = response.json()
+    results_actual = [r["name"] for r in data["results"]["apps"]]
+
+    assert not PlayerAdmin.search_fields
+    assert response.status_code == 200
+    assert len(results_actual) == 0
+
+
+def test_objects_admin_search_fields_relations(client_super_admin):
+    """Verify that relations are searched, if defined in the corresponding admin search_fields"""
+    team = TeamFactory(name="team-1")
+    squad_1 = SquadFactory(team=team)
+    squad_2 = SquadFactory(team=team)
+
+    # other team with other squad
+    team_other = TeamFactory(name="team-2")
+    SquadFactory(team=team_other)
+
+    response = request_search(
+        client_super_admin, query="team-1", site_search_method="admin_search_fields"
+    )
+
+    data = response.json()
+    results = {}
+
+    for app in data["results"]["apps"]:
+        for model in app["models"]:
+            results[model["name"]] = [o["id"] for o in model["objects"]]
+
+    assert SquadAdmin.search_fields == ("team__name", "players__name")
+    assert len(results["Squads"]) == 2
+    assert str(squad_1.id) in results["Squads"]
+    assert str(squad_2.id) in results["Squads"]
+    assert len(results["Teams"]) == 1
+    assert str(team.id) in results["Teams"]
+
+
+def test_objects_admin_search_fields_distinct(client_super_admin):
+    """Verify that duplicates are removed, if they arise from relation many-to-many searches"""
+    squad = SquadFactory()
+    player_1 = PlayerFactory(name="John Doe")
+    player_2 = PlayerFactory(name="Doe John")
+    squad.players.add(player_1, player_2)
+
+    response = request_search(
+        client_super_admin, query="john", site_search_method="admin_search_fields"
+    )
+
+    data = response.json()
+    results = data["results"]["apps"][0]["models"][0]["objects"]
+
+    assert SquadAdmin.search_fields == ("team__name", "players__name")
+    assert len(results) == 1
+    assert results[0]["id"] == str(squad.id)
+
+
+def test_objects_method_default():
+    """Verify that, by default, site_search_method=model_char_fields.
+
+    This is set to avoid breaking changes in behaviour."""
+    assert AdminSiteSearchView.site_search_method == "model_char_fields"


### PR DESCRIPTION
Todo:
- [x] Decide on best API. Use `site_search_method` string, or something else?
- [x] Pass `request` through to `get_search_results(...)`.
- [x] Update documentation/readme.