### PR TITLE
Add get_model_queryset() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,31 +105,37 @@ class MyAdminSite(AdminSiteSearchView, admin.AdminSite):
 ### Methods
 
 ```python 
-def match_app(self, request, query: str, name: str) -> bool:
+def match_app(
+    self, request, query: str, name: str
+) -> bool:
     """DEFAULT: case-insensitive match the app name"""
-    ...
 
 def match_model(
     self, request, query: str, name: str, object_name: str, fields: List[Field]
 ) -> bool:
     """DEFAULT: case-insensitive match the model and field attributes"""
-    ...
 
 def match_objects(
     self, request, query: str, model_class: Model, model_fields: List[Field]
 ) -> QuerySet:
     """DEFAULT: Returns the QuerySet after performing an OR filter across all Char fields in the model."""
-    ...
 
-def filter_field(self, request, query: str, field: Field) -> Optional[Q]:
+def filter_field(
+    self, request, query: str, field: Field
+) -> Optional[Q]:
     """DEFAULT: Returns a Q 'icontains' filter for Char fields, otherwise None
     
     Note: this method is only invoked if model_char_fields is the site_search_method."""
-    ...
 
-def get_model_class(self, request, app_label: str, model_dict: dict) -> Optional[Model]:
+def get_model_queryset(
+    self, request, model_class: Model, model_admin: Optional[ModelAdmin]
+) -> QuerySet:
+    """DEFAULT: Returns the model class' .objects.all() queryset."""
+
+def get_model_class(
+    self, request, app_label: str, model_dict: dict
+) -> Optional[Model]:
     """DEFAULT: Retrieve the model class from the dict created by admin.AdminSite"""
-    ...
 ```
 
 #### Example

--- a/tests/server/test_override.py
+++ b/tests/server/test_override.py
@@ -10,7 +10,9 @@ from django.contrib.auth.models import Permission, User
 from django.http import HttpRequest
 from django.test import Client
 
+from dev.football.stadiums.admin import StadiumAdmin
 from dev.football.stadiums.models import Stadium
+from dev.football.teams.admin import TeamAdmin
 from dev.football.teams.models import Team
 from tests import request_search
 
@@ -116,6 +118,22 @@ def test_filter_field_not_invoked(request_with_patch):
     )
 
     assert patch_field_fields.call_count == 0
+
+
+def test_get_model_queryset(request_with_patch):
+    """Verify that the get_model_queryset method is correctly invoked for each model that the user
+    has access to"""
+    patch_get_model_queryset = request_with_patch(method_name="get_model_queryset")
+    call_args_list = [c[0] for c in patch_get_model_queryset.call_args_list]
+
+    assert len(call_args_list) == 2
+    _assert_request_first_arg(call_args_list)
+
+    assert call_args_list[0][1] == Stadium
+    assert isinstance(call_args_list[0][2], StadiumAdmin)
+
+    assert call_args_list[1][1] == Team
+    assert isinstance(call_args_list[1][2], TeamAdmin)
 
 
 def test_get_model_class(request_with_patch):


### PR DESCRIPTION
Rather than hard-coding model.objects.all(), defer to a `get_model_queryset()` method to allow for easier customisation.

Issue: https://github.com/ahmedaljawahiry/django-admin-site-search/issues/33